### PR TITLE
Added initial code for subscribe to all flood

### DIFF
--- a/test-runner/package.json
+++ b/test-runner/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "node ./bin/index.js",
     "build": "tsc",
-    "dev": "node ./bin/index.js --connection-string \"esdb://c0e0d3arh41g7drr2ilg.mesdb.eventstore.cloud:2113\"",
+    "dev": "node ./bin/index.js --connection-string \"esdb://admin:changeit@c0e0d3arh41g7drr2ilg.mesdb.eventstore.cloud:2113\"",
     "profile": "tsc && node --prof ./bin/index.js --connection-string \"esdb://c0e0d3arh41g7drr2ilg.mesdb.eventstore.cloud:2113\""
   },
   "dependencies": {

--- a/test-runner/readme.md
+++ b/test-runner/readme.md
@@ -82,3 +82,22 @@ yarn start rdfl --connection-string "esdb://c0e0d3arh41g7drr2ilg.mesdb.eventstor
 | --deterministic_stream_selection | Write to streams sequentually                     | boolean |          | false         |
 | --worker_count                   | number of workers to use                          | number  |          | cpu count - 1 |
 | --max_in_flight                  | Maximum number of requests in flight (Per client) | number  |          | Infinity      |
+
+### safl
+
+Multi Read Processor from subscription across workers
+
+#### Example:
+
+```
+yarn start safl --connection-string "esdb://c0e0d3arh41g7drr2ilg.mesdb.eventstore.cloud:2113" --client_count=1 --total_events_to_read=200
+```
+
+#### Options:
+
+|                                  | description                                       | type    | required | default       |
+| -------------------------------- | ------------------------------------------------- | ------- | -------- | ------------- |
+| --client_count                   | Number of clients to use                          | number  | yes      |               |
+| --worker_count                   | Number of workers to use                          | number  |          | cpu count - 1 |
+| --total_events_to_read           | Total number of events to read from subscription  | number  |          | 1000          |
+| --report_per_number_of_events    | Report progress per number of events              | number  |          | 1000          |

--- a/test-runner/readme.md
+++ b/test-runner/readme.md
@@ -95,9 +95,11 @@ yarn start safl --connection-string "esdb://c0e0d3arh41g7drr2ilg.mesdb.eventstor
 
 #### Options:
 
-|                                  | description                                       | type    | required | default       |
-| -------------------------------- | ------------------------------------------------- | ------- | -------- | ------------- |
-| --client_count                   | Number of clients to use                          | number  | yes      |               |
-| --worker_count                   | Number of workers to use                          | number  |          | cpu count - 1 |
-| --total_events_to_read           | Total number of events to read from subscription  | number  |          | 1000          |
-| --report_per_number_of_events    | Report progress per number of events              | number  |          | 1000          |
+|                               | description                                      | type                 | required | default       |
+| ----------------------------- | ------------------------------------------------ | -------------------- | -------- | ------------- |
+| --client_count                | Number of clients to use                         | number               | yes      |               |
+| --worker_count                | Number of workers to use                         | number               |          | cpu count - 1 |
+| --total_events_to_read        | Total number of events to read from subscription | number               |          | 1000          |
+| --report_per_number_of_events | Report progress per number of events             | number               |          | 1000          |
+| --from_position               | Start of subscription                            | `'start'` or `'end'` |          | `'start'`     |
+| --resolve_link_tos            | Resolve link tos                                 | boolean              |          | false         |

--- a/test-runner/src/commands/safl/index.ts
+++ b/test-runner/src/commands/safl/index.ts
@@ -1,0 +1,166 @@
+import type { CommandModule } from "yargs";
+
+import { performance, PerformanceObserver } from "perf_hooks";
+import { Worker } from "worker_threads";
+import { cpus } from "os";
+
+import { Init, ResponseMsg, WToPMsg } from "./types";
+
+interface Options {
+  connectionString: string;
+  client_count: number;
+  worker_count: number;
+  total_events_to_read: number;
+  report_per_number_of_events: number;
+}
+
+const safl: CommandModule<{}, Options> = {
+  command: "safl",
+  describe: "Multi Subscribe To All Processor",
+  builder: {
+    client_count: {
+      type: "number",
+      demandOption: true,
+    },
+    worker_count: {
+      type: "number",
+      default: cpus().length - 1,
+    },
+    total_events_to_read: {
+      type: "number",
+      default: 1000,
+    },
+    report_per_number_of_events: {
+      type: "number",
+      default: 1000,
+    },
+  },
+  handler,
+};
+
+async function handler({
+  client_count: clientCount,
+  worker_count,
+  total_events_to_read: totalEventsToRead,
+  report_per_number_of_events: reportPerNumberOfEvents,
+  connectionString,
+}: Options) {
+  const workerCount = Math.min(clientCount, worker_count);
+
+  const splitInteger = (num: number, parts: number) => {
+    const mod = num % parts;
+    const val = (num - mod) / parts;
+    const result = Array(parts).fill(val);
+    for (let i = 0; i < mod; i++) {
+      result[i] += 1;
+    }
+    return result;
+  };
+
+  const workerCounts = splitInteger(clientCount, workerCount).map(
+    (clientsForWorker) => ({
+      clientCount: clientsForWorker,
+    })
+  );
+
+  let success = 0;
+  let failure = 0;
+  const failures = new Map<string, number>();
+
+  const perfObserver = new PerformanceObserver((items) => {
+    items.getEntries().forEach(({ duration }) => {
+      const eventsSent = success + failure;
+
+      console.log(
+        `DONE TOTAL ${eventsSent} READS IN ${duration}ms (${
+          (1000.0 * eventsSent) / duration
+        }/s)`
+      );
+      console.log(`SUCCESS: ${success} FAILURE: ${failure}`);
+
+      if (failures.size) {
+        console.log(
+          `failures: \n${Array.from(failures)
+            .map(([error, count]) => `${`${count}x`.padEnd(12, " ")}| ${error}`)
+            .join("\n")}`
+        );
+      }
+    });
+  });
+
+  perfObserver.observe({ entryTypes: ["measure"], buffered: true });
+
+  performance.mark("subscribe-to-all-start");
+
+  const promises = await Promise.allSettled(
+    workerCounts.map(({ clientCount }, i) =>
+      spawnWorker({
+        id: `${i}`,
+        clientCount,
+        connectionString,
+        totalEventsToRead,
+        reportPerNumberOfEvents,
+      })
+    )
+  );
+
+  performance.mark("subscribe-to-all-end");
+
+  for (const result of promises) {
+    if (result.status === "fulfilled") {
+      success += result.value.success;
+      failure += result.value.failure;
+
+      for (const [error, count] of result.value.failures) {
+        const fail = error.toString();
+        failures.set(fail, (failures.get(fail) ?? 0) + count);
+      }
+    } else {
+      console.log("FAILURE: ", result.reason);
+    }
+  }
+
+  // lazy way to get this last
+  setTimeout(
+    () =>
+      performance.measure(
+        "subscribe-to-all",
+        "subscribe-to-all-start",
+        "subscribe-to-all-end"
+      ),
+    500
+  );
+}
+
+function spawnWorker(options: Init): Promise<ResponseMsg> {
+  return new Promise((resolve, reject) => {
+    console.log(
+      `spawning worker ${options.id} with ${options.clientCount} clients`,
+      options
+    );
+    const worker = new Worker(require.resolve("./safl.worker"), {
+      workerData: options,
+      stdout: true,
+    });
+    worker.on("message", (msg: WToPMsg) => {
+      switch (msg.type) {
+        case "finished": {
+          resolve(msg);
+          break;
+        }
+        case "perf": {
+          console.log(msg.message);
+          break;
+        }
+      }
+    });
+    worker.on("error", reject);
+    worker.on("exit", (code) => {
+      if (code !== 0)
+        reject(new Error(`Worker stopped with exit code ${code}`));
+    });
+    worker.stdout.pipe(process.stdout);
+  });
+}
+
+export default safl;

--- a/test-runner/src/commands/safl/safl.worker.ts
+++ b/test-runner/src/commands/safl/safl.worker.ts
@@ -128,11 +128,6 @@ async function runClient({
     done = r;
   });
 
-  let landed!: () => void;
-  const letNextEventThrough = () => {
-    landed();
-  };
-
   let success = 0;
   let failure = 0;
   let total = 0;
@@ -157,7 +152,6 @@ async function runClient({
       const fail = error.toString();
       failures.set(fail, (failures.get(fail) ?? 0) + 1);
 
-      letNextEventThrough();
       done();
     });
 

--- a/test-runner/src/commands/safl/safl.worker.ts
+++ b/test-runner/src/commands/safl/safl.worker.ts
@@ -1,0 +1,171 @@
+import { parentPort, workerData } from "worker_threads";
+import { performance, PerformanceObserver } from "perf_hooks";
+import { EventStoreDBClient } from "@eventstore/db-client";
+import { Init, PToWMsg, ResponseMsg } from "./types";
+import { ResolvedEvent } from "@eventstore/db-client";
+
+const onStreamName: Array<(name: string) => void> = [];
+
+parentPort!.on("message", (msg: PToWMsg) => {
+  switch (msg.type) {
+    case "requestStream": {
+      const next = onStreamName.shift();
+      next?.(msg.streamName);
+      break;
+    }
+    default:
+      break;
+  }
+});
+
+async function initialize({
+  connectionString,
+  clientCount,
+  id,
+  totalEventsToRead,
+  reportPerNumberOfEvents,
+}: Init) {
+  const perfObserver = new PerformanceObserver((items) => {
+    items.getEntries().forEach(({ name, duration }) => {
+      const eventsSent = name.startsWith("worker")
+        ? clientCount * totalEventsToRead
+        : totalEventsToRead;
+      parentPort!.postMessage({
+        type: "perf",
+        message: `${name.toUpperCase()} ${eventsSent} READS FROM SUBSCRIPTION IN ${duration}ms (${
+          (1000.0 * eventsSent) / duration
+        }/s)`,
+      });
+    });
+
+    process.exit();
+  });
+  perfObserver.observe({ entryTypes: ["measure"], buffered: true });
+
+  performance.mark("reads-start");
+
+  const results = await Promise.allSettled(
+    Array.from({ length: clientCount }, (_, i) =>
+      runClient({
+        id: `${i}`,
+        connectionString,
+        totalEventsToRead,
+        reportPerNumberOfEvents,
+      })
+    )
+  );
+
+  performance.mark("reads-end");
+
+  let success = 0;
+  let failure = 0;
+
+  const failures = new Map<string, number>();
+
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      const {
+        id: clientId,
+        success: s,
+        failure: f,
+        failures: fs,
+      } = result.value;
+      success += s;
+      failure += f;
+
+      for (const [fail, count] of fs) {
+        failures.set(fail, (failures.get(fail) ?? 0) + count);
+      }
+
+      if (clientCount > 1) {
+        performance.measure(
+          `       client ${clientId}: `,
+          `${clientId}-reads-start`,
+          `${clientId}-reads-end`
+        );
+      }
+    } else {
+      console.log("critical failure");
+    }
+  }
+
+  const finalResult: ResponseMsg = {
+    type: "finished",
+    success,
+    failure,
+    failures: Array.from(failures),
+  };
+
+  parentPort!.postMessage(finalResult);
+
+  performance.measure(`worker ${id} totals: `, "reads-start", "reads-end");
+}
+
+interface ClientResult {
+  id: string;
+  success: number;
+  failure: number;
+  failures: Map<string, number>;
+}
+
+interface RunClientOptions {
+  id: string;
+  connectionString: string;
+  totalEventsToRead: number;
+  reportPerNumberOfEvents: number;
+}
+
+async function runClient({
+  id,
+  connectionString,
+  totalEventsToRead,
+  reportPerNumberOfEvents,
+}: RunClientOptions): Promise<ClientResult> {
+  const client = EventStoreDBClient.connectionString(connectionString);
+
+  let done!: () => void;
+  const waitForAll = new Promise<void>((r) => {
+    done = r;
+  });
+
+  let landed!: () => void;
+  const letNextEventThrough = () => {
+    landed();
+  };
+
+  let success = 0;
+  let failure = 0;
+  let total = 0;
+  const failures = new Map<string, number>();
+
+  performance.mark(`${id}-subscribe-to-all-start`);
+
+  const subscription = client
+    .subscribeToAll()
+    .on("data", function (_resolvedEvent: ResolvedEvent) {
+      success++;
+      total++;
+
+      if (total === totalEventsToRead) {
+        subscription.destroy();
+        done();
+      }
+    })
+    .on("error", (error) => {
+      failure++;
+      total++;
+      const fail = error.toString();
+      failures.set(fail, (failures.get(fail) ?? 0) + 1);
+
+      letNextEventThrough();
+      done();
+    });
+
+  await waitForAll;
+
+  performance.mark(`${id}-subscribe-to-all-end`);
+
+  return { id, success, failure, failures };
+}
+
+initialize(workerData);

--- a/test-runner/src/commands/safl/types.ts
+++ b/test-runner/src/commands/safl/types.ts
@@ -1,0 +1,31 @@
+export interface Init {
+  id: string;
+  clientCount: number;
+  connectionString: string;
+  totalEventsToRead: number;
+  reportPerNumberOfEvents: number;
+}
+
+export interface ResponseMsg {
+  type: "finished";
+  success: number;
+  failure: number;
+  failures: Array<[string, number]>;
+}
+
+export interface PerformanceMsg {
+  type: "perf";
+  message: string;
+}
+
+export interface RequestStreamMsg {
+  type: "requestStream";
+}
+
+export interface StreamMsg {
+  type: "requestStream";
+  streamName: string;
+}
+
+export type PToWMsg = StreamMsg;
+export type WToPMsg = ResponseMsg | RequestStreamMsg | PerformanceMsg;

--- a/test-runner/src/commands/safl/types.ts
+++ b/test-runner/src/commands/safl/types.ts
@@ -1,9 +1,13 @@
+import type { ReadPosition } from "@eventstore/db-client";
+
 export interface Init {
   id: string;
   clientCount: number;
   connectionString: string;
-  totalEventsToRead: number;
+  eventsPerClient: number;
   reportPerNumberOfEvents: number;
+  fromPosition: ReadPosition;
+  resolveLinkTos: boolean;
 }
 
 export interface ResponseMsg {
@@ -18,14 +22,4 @@ export interface PerformanceMsg {
   message: string;
 }
 
-export interface RequestStreamMsg {
-  type: "requestStream";
-}
-
-export interface StreamMsg {
-  type: "requestStream";
-  streamName: string;
-}
-
-export type PToWMsg = StreamMsg;
-export type WToPMsg = ResponseMsg | RequestStreamMsg | PerformanceMsg;
+export type WToPMsg = ResponseMsg | PerformanceMsg;

--- a/test-runner/src/index.ts
+++ b/test-runner/src/index.ts
@@ -2,11 +2,13 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
 import rdfl from "./commands/rdfl";
+import safl from "./commands/safl";
 import wrfl from "./commands/wrfl";
 
 yargs(hideBin(process.argv))
   .command(wrfl)
   .command(rdfl)
+  .command(safl)
   .demandCommand(1)
   .option("connection-string", {
     alias: "s",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,7 +4,7 @@
 
 "@eventstore/db-client-uint8@../clients/eventstore-db-client-v1.2.1.tgz":
   version "1.2.1"
-  resolved "../clients/eventstore-db-client-v1.2.1.tgz#67a0cf8aeb069ae35523c5513d7ad4984854264e"
+  resolved "./clients/eventstore-db-client-v1.2.1.tgz#67a0cf8aeb069ae35523c5513d7ad4984854264e"
   dependencies:
     "@grpc/grpc-js" "^1.2.2"
     "@types/debug" "^4.1.5"


### PR DESCRIPTION
Added initial implementation for the Subscribe to all read flood.

Left to do: 
- implement reporting progress per set number of events (`report_per_number_of_events` parameter)
- to be discussed with @condron - read delay per set number of events (might be obsolete because of the built-in NodeJS streams back-pressure)